### PR TITLE
fix(gradle): support @nativescript/android@8.2.2

### DIFF
--- a/src/platforms/android/include.gradle
+++ b/src/platforms/android/include.gradle
@@ -10,5 +10,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.github.kenglxn.QRGen:android:2.6.0'
+    implementation 'com.github.kenglxn.QRGen:android:2.6.0'
 }


### PR DESCRIPTION
Hi @erodriguezh,

Thanks for your plugin it's really cool, I just made a small modification related to the new version of @nativescript/android, without it I can't build my application (@nativescript/core@8.2.1). More information [here](https://github.com/NativeScript/NativeScript/issues/9827).